### PR TITLE
Peer Hashing Implementation

### DIFF
--- a/cockroach/cockroach.go
+++ b/cockroach/cockroach.go
@@ -174,6 +174,12 @@ func (c *DB) CreateBulk(objs []interface{}, options ...patchain.Option) error {
 	return nil
 }
 
+// UpdatePeerHash updates the peer hash of an object
+func (c *DB) UpdatePeerHash(obj interface{}, newPeerHash string, options ...patchain.Option) error {
+	dbTx, _ := c.getDBTxFromOption(options, &DB{db: c.db})
+	return dbTx.GetConn().(*gorm.DB).Model(obj).Update("peer_hash", newPeerHash).Error
+}
+
 // NewDB creates a new connection
 func (c *DB) NewDB() patchain.DB {
 	return &DB{db: c.db.NewScope(nil).NewDB()}

--- a/cockroach/tables/object.go
+++ b/cockroach/tables/object.go
@@ -22,7 +22,8 @@ type Object struct {
 	Protected     bool                 `json:"protected,omitempty" structs:"protected,omitempty" mapstructure:"protected,omitempty"`
 	RefOnly       bool                 `json:"ref_only,omitempty" structs:"refOnly,omitempty" mapstructure:"refOnly,omitempty"`
 	Timestamp     int64                `json:"timestamp,omitempty" structs:"timestamp,omitempty" mapstructure:"timestamp,omitempty"`
-	PrevHash      string               `json:"prev_hash,omitempty" structs:"prevHash,omitempty" mapstructure:"prevHash,omitempty" gorm:"type:varchar(70);unique_index:idx_prev_hash"`
+	PrevHash      *string              `json:"prev_hash,omitempty" structs:"prevHash,omitempty" mapstructure:"prevHash,omitempty" gorm:"type:varchar(70)"`
+	PeerHash      *string              `json:"peer_hash,omitempty" structs:"peerHash,omitempty" mapstructure:"peerHash,omitempty" gorm:"type:varchar(70);unique_index:idx_peer_hash"`
 	Hash          string               `json:"hash,omitempty" structs:"hash,omitempty" mapstructure:"hash,omitempty" gorm:"unique_index:idx_hash"`
 	SchemaVersion string               `json:"schema_version,omitempty" structs:"schemaVersion,omitempty" mapstructure:"schemaVersion,omitempty"`
 	Ref1          string               `json:"ref1,omitempty" structs:"ref1,omitempty" mapstructure:"ref1,omitempty" gorm:"type:varchar(64)"`
@@ -47,8 +48,9 @@ func (o *Object) Init() *Object {
 	}
 
 	// set the previous hash to the sha256 hash off the object's ID it not already set.
-	if o.PrevHash == "" {
-		o.PrevHash = util.Sha256(o.ID)
+	if o.PrevHash == nil {
+		prevHash := util.Sha256(o.ID)
+		o.PrevHash = &prevHash
 	}
 
 	if o.Timestamp == 0 {
@@ -72,12 +74,22 @@ func (o *Object) ComputeHash() *Object {
 			o.Protected,
 			o.RefOnly,
 			o.Timestamp,
-			o.PrevHash,
+			*o.PrevHash,
 			o.SchemaVersion,
 			o.Ref1, o.Ref2, o.Ref3, o.Ref4, o.Ref5, o.Ref6, o.Ref7, o.Ref8, o.Ref9, o.Ref10,
 		))
 	}
 
+	return o
+}
+
+// ComputePeerHash computes the peer hash. A peer hash binds the current object
+// to the object next object.
+func (o *Object) ComputePeerHash(nextObjHash string) *Object {
+	if o.SchemaVersion == "1" {
+		peerHash := util.Sha256(fmt.Sprintf("%s/%s", o.Hash, nextObjHash))
+		o.PeerHash = &peerHash
+	}
 	return o
 }
 

--- a/cockroach/tables/object_test.go
+++ b/cockroach/tables/object_test.go
@@ -1,8 +1,10 @@
 package tables
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/ellcrys/util"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -42,6 +44,23 @@ func TestObject(t *testing.T) {
 				hash := obj.Hash
 				obj.ComputeHash()
 				So(obj.Hash, ShouldEqual, hash)
+			})
+		})
+
+		Convey(".Compute", func() {
+			Convey("Should create hash and must return same hash as long as object remains unchanged", func() {
+				obj := Object{
+					CreatorID:   "creator_1",
+					OwnerID:     "owner_1",
+					PartitionID: "partition_1",
+					Hash:        "abc",
+				}
+				obj.Init()
+				So(obj.PeerHash, ShouldBeNil)
+				nextObjHash := "some_hash"
+				obj.ComputePeerHash(nextObjHash)
+				peerHash := util.Sha256(fmt.Sprintf("%s/%s", obj.Hash, nextObjHash))
+				So(obj.PeerHash, ShouldResemble, &peerHash)
 			})
 		})
 	})

--- a/db.go
+++ b/db.go
@@ -35,6 +35,9 @@ type DB interface {
 	// CreateBulk is like Create but supports multiple objects
 	CreateBulk(objs []interface{}, options ...Option) error
 
+	// UpdatePeerHash updates the peer hash of an object
+	UpdatePeerHash(obj interface{}, newPeerHash string, options ...Option) error
+
 	// Count counts the number of objects in the patchain that matches a query
 	Count(q Query, out *int64, options ...Option) error
 

--- a/object/object.go
+++ b/object/object.go
@@ -92,14 +92,41 @@ func (o *Object) CreatePartitions(n int64, ownerID, creatorID string, options ..
 			// last partition, add the new partitions
 			partitionsI, _ := util.ToSliceInterface(partitions)
 			if lastPartition == nil {
-				return o.db.CreateBulk(partitionsI, dbOptions...)
+
+				if err := o.db.CreateBulk(partitionsI, dbOptions...); err != nil {
+					return errors.Wrap(err, "failed to create partition")
+				}
+
+				// create genesis pair for each partition
+				for _, partition := range partitions {
+					gPair := MakeGenesisPair(ownerID, creatorID, partition.ID, partition.Hash)
+					gPairI, _ := util.ToSliceInterface(gPair)
+					if err := o.db.CreateBulk(gPairI, dbOptions...); err != nil {
+						return errors.Wrap(err, "failed to create genesis object")
+					}
+				}
+
+				return nil
 			}
 
 			// update the previous hash of the first of the new partitions
 			// to the hash of the last partition
 			partitionsI[0].(*tables.Object).PrevHash = util.StrToPtr(lastPartition.Hash)
 			MakeChain(partitions...)
-			return o.db.CreateBulk(partitionsI, dbOptions...)
+			if err := o.db.CreateBulk(partitionsI, dbOptions...); err != nil {
+				return errors.Wrap(err, "failed to create partition")
+			}
+
+			// create genesis pair for each partition
+			for _, partition := range partitions {
+				gPair := MakeGenesisPair(ownerID, creatorID, partition.ID, partition.Hash)
+				gPairI, _ := util.ToSliceInterface(gPair)
+				if err := o.db.CreateBulk(gPairI, dbOptions...); err != nil {
+					return errors.Wrap(err, "failed to create genesis object")
+				}
+			}
+
+			return nil
 		})
 	}
 
@@ -270,16 +297,9 @@ func (o *Object) Put(objs interface{}, options ...patchain.Option) error {
 			// get the last object of the selected partition
 			lastObj, err := o.GetLast(&tables.Object{PartitionID: selectedPartition.ID}, dbOptions...)
 			if err != nil {
-				// no object in this partition! Use the hash of the partition as the PrevHash value
-				// of the first object, chain the objects and create them
+				// no object in this partition! This means no genesis pair/object, return error
 				if err == patchain.ErrNotFound {
-					objects[0].PrevHash = util.StrToPtr(selectedPartition.Hash)
-					MakeChain(objects...)
-					for _, o := range objects {
-						if err = dbTx.Create(o, options...); err != nil {
-							return errors.Wrap(err, "failed to add object to partition")
-						}
-					}
+					return fmt.Errorf("no genesis object in the partition")
 				}
 				return err
 			}

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -70,7 +70,7 @@ func TestObject(t *testing.T) {
 	Convey("Object", t, func() {
 		Convey(".Create", func() {
 			Convey("Should initialize and create an object", func() {
-				o := &tables.Object{Key: "some_key", Value: "some_value", PrevHash: util.UUID4()}
+				o := &tables.Object{Key: "some_key", Value: "some_value", PrevHash: util.StrToPtr(util.UUID4())}
 				So(o.ID, ShouldBeEmpty)
 				So(o.Timestamp, ShouldEqual, 0)
 				So(o.Hash, ShouldBeEmpty)
@@ -82,7 +82,7 @@ func TestObject(t *testing.T) {
 
 				Convey("Should create duplicate key object with same key", func() {
 					o.ID = util.UUID4()
-					o.PrevHash = util.UUID4()
+					o.PrevHash = util.StrToPtr(util.UUID4())
 					err := obj.Create(o)
 					So(err, ShouldBeNil)
 					count := int64(0)
@@ -98,7 +98,7 @@ func TestObject(t *testing.T) {
 
 			Convey(".CreateOnce", func() {
 				Convey("Should initialize and create an object", func() {
-					o := &tables.Object{Key: "some_key", Value: "some_value", PrevHash: util.UUID4()}
+					o := &tables.Object{Key: "some_key", Value: "some_value", PrevHash: util.StrToPtr(util.UUID4())}
 					So(o.ID, ShouldBeEmpty)
 					So(o.Timestamp, ShouldEqual, 0)
 					So(o.Hash, ShouldBeEmpty)
@@ -110,7 +110,7 @@ func TestObject(t *testing.T) {
 
 					Convey("Should not create duplicate key object and also return no error", func() {
 						o.ID = util.UUID4()
-						o.PrevHash = util.UUID4()
+						o.PrevHash = util.StrToPtr(util.UUID4())
 						err := obj.CreateOnce(o)
 						So(err, ShouldBeNil)
 						count := int64(0)
@@ -142,12 +142,12 @@ func TestObject(t *testing.T) {
 					So(len(partitions), ShouldEqual, 3)
 
 					Convey("first partition prev hash must be equal to the SHA256 hash of the ID", func() {
-						So(partitions[0].PrevHash, ShouldEqual, util.Sha256(partitions[0].ID))
+						So(*partitions[0].PrevHash, ShouldEqual, util.Sha256(partitions[0].ID))
 					})
 
 					Convey("partitions must be chained to the partition before it", func() {
-						So(partitions[1].PrevHash, ShouldEqual, "prtn/"+partitions[0].Hash)
-						So(partitions[2].PrevHash, ShouldEqual, "prtn/"+partitions[1].Hash)
+						So(*partitions[1].PrevHash, ShouldEqual, partitions[0].Hash)
+						So(*partitions[2].PrevHash, ShouldEqual, partitions[1].Hash)
 					})
 
 					Convey("New partition must reference the prev hash of the last included partition", func() {
@@ -156,8 +156,8 @@ func TestObject(t *testing.T) {
 						So(len(latestPartitions), ShouldEqual, 2)
 
 						Convey("first partition must reference the prev hash of the last partition", func() {
-							So(latestPartitions[0].PrevHash, ShouldEqual, "prtn/"+partitions[2].Hash)
-							So(latestPartitions[1].PrevHash, ShouldEqual, "prtn/"+latestPartitions[0].Hash)
+							So(*latestPartitions[0].PrevHash, ShouldEqual, partitions[2].Hash)
+							So(*latestPartitions[1].PrevHash, ShouldEqual, latestPartitions[0].Hash)
 						})
 					})
 				})
@@ -175,12 +175,12 @@ func TestObject(t *testing.T) {
 					So(len(partitions), ShouldEqual, 3)
 
 					Convey("first partition prev hash must be equal to the SHA256 hash of the ID", func() {
-						So(partitions[0].PrevHash, ShouldEqual, util.Sha256(partitions[0].ID))
+						So(*partitions[0].PrevHash, ShouldEqual, util.Sha256(partitions[0].ID))
 					})
 
 					Convey("partitions must be chained to the partition before it", func() {
-						So(partitions[1].PrevHash, ShouldEqual, "prtn/"+partitions[0].Hash)
-						So(partitions[2].PrevHash, ShouldEqual, "prtn/"+partitions[1].Hash)
+						So(*partitions[1].PrevHash, ShouldEqual, partitions[0].Hash)
+						So(*partitions[2].PrevHash, ShouldEqual, partitions[1].Hash)
 					})
 
 					Convey("New partition must reference the prev hash of the last included partition", func() {
@@ -189,8 +189,8 @@ func TestObject(t *testing.T) {
 						So(len(latestPartitions), ShouldEqual, 2)
 
 						Convey("first partition must reference the prev hash of the last partition", func() {
-							So(latestPartitions[0].PrevHash, ShouldEqual, "prtn/"+partitions[2].Hash)
-							So(latestPartitions[1].PrevHash, ShouldEqual, "prtn/"+latestPartitions[0].Hash)
+							So(*latestPartitions[0].PrevHash, ShouldEqual, partitions[2].Hash)
+							So(*latestPartitions[1].PrevHash, ShouldEqual, latestPartitions[0].Hash)
 						})
 					})
 				})
@@ -208,9 +208,9 @@ func TestObject(t *testing.T) {
 				})
 
 				Convey("Should return last added object matching the query", func() {
-					o := &tables.Object{Key: "some_key", Value: "some_value", PrevHash: util.UUID4()}
-					o2 := &tables.Object{Key: "some_key", Value: "some_value_2", PrevHash: util.UUID4()}
-					o3 := &tables.Object{Key: "some_key", Value: "some_value_3", PrevHash: util.UUID4()}
+					o := &tables.Object{Key: "some_key", Value: "some_value", PrevHash: util.StrToPtr(util.UUID4())}
+					o2 := &tables.Object{Key: "some_key", Value: "some_value_2", PrevHash: util.StrToPtr(util.UUID4())}
+					o3 := &tables.Object{Key: "some_key", Value: "some_value_3", PrevHash: util.StrToPtr(util.UUID4())}
 					err := obj.Create(o)
 					So(err, ShouldBeNil)
 					err = obj.Create(o2)
@@ -236,8 +236,8 @@ func TestObject(t *testing.T) {
 				})
 
 				Convey("Should successfully fetch all objects", func() {
-					o := &tables.Object{Key: "some_key", Value: "some_value", PrevHash: util.UUID4()}
-					o2 := &tables.Object{Key: "some_key", Value: "some_value_2", PrevHash: util.UUID4()}
+					o := &tables.Object{Key: "some_key", Value: "some_value", PrevHash: util.StrToPtr(util.UUID4())}
+					o2 := &tables.Object{Key: "some_key", Value: "some_value_2", PrevHash: util.StrToPtr(util.UUID4())}
 					err := obj.Create(o)
 					So(err, ShouldBeNil)
 					err = obj.Create(o2)
@@ -323,20 +323,28 @@ func TestObject(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					objs := []*tables.Object{
-						{Key: "key_1", OwnerID: ownerID},
-						{Key: "key_2", OwnerID: ownerID},
-						{Key: "key_3", OwnerID: ownerID},
+						{Key: "key_1", OwnerID: ownerID, SchemaVersion: "1"},
+						{Key: "key_2", OwnerID: ownerID, SchemaVersion: "1"},
+						{Key: "key_3", OwnerID: ownerID, SchemaVersion: "1"},
 					}
 					err = obj.Put(objs)
 					So(err, ShouldBeNil)
-
-					Convey("first object of the partition must the partition hash as the value of its prev hash", func() {
-						So(objs[0].PrevHash, ShouldEqual, partitions[0].Hash)
+					Convey("first object of the partition must have the partition hash as the value of its prev hash", func() {
+						So(*objs[0].PrevHash, ShouldEqual, partitions[0].Hash)
 					})
 
 					Convey("all objects must be chained", func() {
-						So(objs[0].Hash, ShouldEqual, objs[1].PrevHash)
-						So(objs[1].Hash, ShouldEqual, objs[2].PrevHash)
+						So(objs[0].Hash, ShouldEqual, *objs[1].PrevHash)
+						So(objs[1].Hash, ShouldEqual, *objs[2].PrevHash)
+					})
+
+					Convey("all objects with an object after it must have a valid peer hash", func() {
+						So(objs[0].PeerHash, ShouldResemble, objs[0].ComputePeerHash(objs[1].Hash).PeerHash)
+						So(objs[1].PeerHash, ShouldResemble, objs[1].ComputePeerHash(objs[2].Hash).PeerHash)
+
+						Convey("an object with no peer must have no peer hash", func() {
+							So(objs[2].PeerHash, ShouldBeNil)
+						})
 					})
 
 					Convey("Should successfully add an additional object to the non-empty partition", func() {
@@ -345,7 +353,15 @@ func TestObject(t *testing.T) {
 						So(err, ShouldBeNil)
 
 						Convey("new object must have the hash of the previous object as the value of its prev hash", func() {
-							So(objs[2].Hash, ShouldEqual, o.PrevHash)
+							So(objs[2].Hash, ShouldEqual, *o.PrevHash)
+						})
+
+						Convey("preceding object must have a peer hash", func() {
+							var newObj2 tables.Object
+							err := cdb.GetLast(&tables.Object{ID: objs[2].ID}, &newObj2)
+							So(err, ShouldBeNil)
+							So(newObj2.PeerHash, ShouldNotBeNil)
+							So(newObj2.PeerHash, ShouldResemble, newObj2.ComputePeerHash(o.Hash).PeerHash)
 						})
 					})
 				})
@@ -416,12 +432,12 @@ func TestObject(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					Convey("first object of the partition must the partition hash as the value of its prev hash", func() {
-						So(objs[0].PrevHash, ShouldEqual, partitions[0].Hash)
+						So(*objs[0].PrevHash, ShouldEqual, partitions[0].Hash)
 					})
 
 					Convey("all objects must be chained", func() {
-						So(objs[0].Hash, ShouldEqual, objs[1].PrevHash)
-						So(objs[1].Hash, ShouldEqual, objs[2].PrevHash)
+						So(objs[0].Hash, ShouldEqual, *objs[1].PrevHash)
+						So(objs[1].Hash, ShouldEqual, *objs[2].PrevHash)
 					})
 
 					Convey("Should successfully add an additional object to the non-empty partition", func() {
@@ -430,7 +446,7 @@ func TestObject(t *testing.T) {
 						So(err, ShouldBeNil)
 
 						Convey("new object must have the hash of the previous object as the value of its prev hash", func() {
-							So(objs[2].Hash, ShouldEqual, o.PrevHash)
+							So(objs[2].Hash, ShouldEqual, *o.PrevHash)
 						})
 					})
 				})

--- a/object/object_util.go
+++ b/object/object_util.go
@@ -61,28 +61,16 @@ func MakeDeveloperIdentityObject(ownerID, creatorID, email, password string, pro
 }
 
 // MakeChain takes objects and chains them together. Each object referencing the
-// hash of the previous on their PrevHash field.
+// hash of the previous on their PrevHash field and each preceding object
+// calculates its PeerHash which is the hash of its own hash and the hash of the object after
 func MakeChain(objects ...*tables.Object) {
 	for i, object := range objects {
 		object.Init().ComputeHash()
 		if i > 0 {
 			prevObj := objects[i-1]
-			object.PrevHash = prevObj.Hash
+			object.PrevHash = util.StrToPtr(prevObj.Hash)
 			object.ComputeHash()
-		}
-	}
-}
-
-// MakeChainWithPrefix takes objects and chains them together. Each object referencing the
-// hash of the previous on their PrevHash field. prevHashPrefix is used as a flag to tell
-// what kind of object is being chained or as a namespace for certain objects (e.g partitions).
-func MakeChainWithPrefix(prevHashPrefix string, objects ...*tables.Object) {
-	for i, object := range objects {
-		object.Init().ComputeHash()
-		if i > 0 {
-			prevObj := objects[i-1]
-			object.PrevHash = prevHashPrefix + "/" + prevObj.Hash
-			object.ComputeHash()
+			prevObj.ComputePeerHash(object.Hash)
 		}
 	}
 }

--- a/object/object_util.go
+++ b/object/object_util.go
@@ -74,3 +74,23 @@ func MakeChain(objects ...*tables.Object) {
 		}
 	}
 }
+
+// MakeGenesisPair creates two objects to be used as genesis object pairs
+func MakeGenesisPair(ownerID, creatorID, partitionID, partitionHash string) []*tables.Object {
+	pair := []*tables.Object{{
+		OwnerID:       ownerID,
+		CreatorID:     creatorID,
+		PartitionID:   partitionID,
+		Key:           "$genesis/1",
+		SchemaVersion: "1",
+		PrevHash:      util.StrToPtr(partitionHash),
+	}, {
+		OwnerID:       ownerID,
+		CreatorID:     creatorID,
+		PartitionID:   partitionID,
+		Key:           "$genesis/2",
+		SchemaVersion: "1",
+	}}
+	MakeChain(pair...)
+	return pair
+}

--- a/object/object_util_test.go
+++ b/object/object_util_test.go
@@ -64,5 +64,14 @@ func TestObjectUtil(t *testing.T) {
 				})
 			})
 		})
+
+		Convey(".MakeGenesisPair", func() {
+			pair := MakeGenesisPair("owner_id", "creator_id", "partition_id", "partition_hash")
+			So(pair[0].Key, ShouldEqual, "$genesis/1")
+			So(pair[1].Key, ShouldEqual, "$genesis/2")
+			So(*pair[0].PrevHash, ShouldEqual, "partition_hash")
+			So(pair[0].Hash, ShouldEqual, *pair[1].PrevHash)
+			So(pair[0].PeerHash, ShouldResemble, pair[0].ComputePeerHash(pair[1].Hash).PeerHash)
+		})
 	})
 }

--- a/vendor/github.com/ellcrys/util/utility.go
+++ b/vendor/github.com/ellcrys/util/utility.go
@@ -15,10 +15,12 @@ import (
 	r "math/rand"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"golang.org/x/net/context"
@@ -38,6 +40,7 @@ import (
 	spin "github.com/ncodes/go-spin"
 	"github.com/ncodes/mapstructure"
 	"github.com/satori/go.uuid"
+	context2 "golang.org/x/net/context"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -253,12 +256,9 @@ func IsMapOfAny(any interface{}) bool {
 	switch any.(type) {
 	case map[string]interface{}:
 		return true
-		break
 	default:
 		return false
-		break
 	}
-	return false
 }
 
 // IsSlice checks that a variable value type is a slice
@@ -266,12 +266,9 @@ func IsSlice(any interface{}) bool {
 	switch any.(type) {
 	case []interface{}:
 		return true
-		break
 	default:
 		return false
-		break
 	}
-	return false
 }
 
 // ContainsOnlyMapType checks that a slice contains map[string]interface{} type
@@ -280,7 +277,6 @@ func ContainsOnlyMapType(s []interface{}) bool {
 		switch v.(type) {
 		case map[string]interface{}:
 			continue
-			break
 		default:
 			return false
 		}
@@ -294,7 +290,6 @@ func IsSliceOfStrings(s []interface{}) bool {
 		switch v.(type) {
 		case string:
 			continue
-			break
 		default:
 			return false
 		}
@@ -354,21 +349,16 @@ func ToInt64(num interface{}) int64 {
 	switch v := num.(type) {
 	case int:
 		return int64(v)
-		break
 	case int64:
 		return v
-		break
 	case float64:
 		return int64(v)
-		break
 	case string:
 		val, _ := strconv.ParseInt(v, 10, 64)
 		return val
-		break
 	default:
 		panic("type is unsupported")
 	}
-	return 0
 }
 
 // Env gets environment variable or return a default value when no set
@@ -515,14 +505,12 @@ func JSONNumberToInt64(val interface{}) int64 {
 			panic("JSONNumberToInt64: " + err.Error())
 		}
 		return num
-		break
 	default:
 		panic("JSONNumberToInt64: unknown type. Expects json.Number")
 	}
-	return 0
 }
 
-//  ToJSON converts struct or map to json
+// ToJSON converts struct or map to json
 func ToJSON(data interface{}) ([]byte, error) {
 	return json.Marshal(data)
 }
@@ -845,4 +833,53 @@ func GetAuthToken(ctx context.Context, scheme string) (string, error) {
 	}
 
 	return authSplit[1], nil
+}
+
+// OnTerminate calls a function when a terminate or interrupt signal is received.
+func OnTerminate(f func(s os.Signal)) {
+	sigs := make(chan os.Signal)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		s := <-sigs
+		f(s)
+	}()
+}
+
+// FromMD gets a metadata field from a context of metadata.MD
+func FromMD(d interface{}, key string) string {
+	var md metadata.MD
+	switch _d := d.(type) {
+	case context2.Context:
+		md, _ = metadata.FromOutgoingContext(_d)
+	case metadata.MD:
+		md = _d
+	default:
+		panic(fmt.Errorf("unexpected value type"))
+	}
+	if md[key] == nil {
+		return ""
+	}
+	return md[key][0]
+}
+
+// FromIncomingMD gets a metadata field from a context's incoming metadata
+func FromIncomingMD(d interface{}, key string) string {
+	var md metadata.MD
+	switch _d := d.(type) {
+	case context2.Context:
+		md, _ = metadata.FromIncomingContext(_d)
+	case metadata.MD:
+		md = _d
+	default:
+		panic(fmt.Errorf("unexpected value type"))
+	}
+	if md[key] == nil {
+		return ""
+	}
+	return md[key][0]
+}
+
+// StrToPtr returns a pointer to a string
+func StrToPtr(str string) *string {
+	return &str
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,10 +45,10 @@
 			"revisionTime": "2017-05-12T16:57:09Z"
 		},
 		{
-			"checksumSHA1": "JBkDoj38cNUHNFbP55izxidsjCA=",
+			"checksumSHA1": "oDMMVKk2XWcoLvTzjo4Lq4oFp8U=",
 			"path": "github.com/ellcrys/util",
-			"revision": "be4b1800d2033f32b558fceb4f4fed2f017472c7",
-			"revisionTime": "2017-05-21T10:03:04Z"
+			"revision": "2fd8ddba0fb5bfc40ebdbfa37e84810e576cdf43",
+			"revisionTime": "2017-05-31T11:00:58Z"
 		},
 		{
 			"checksumSHA1": "x77xUarDfVxctJMAJPCQzlYk8JM=",


### PR DESCRIPTION
Implemented Peer hash mechanism for binding an object and the object that comes after it together. This scheme will allow data written to the patchain to be more tamper resistant. For example, In the regular blockchain transaction chain model, each transaction references the hash of the transaction before it to create an accurate history of all transactions. When an attacker makes changes at the middle of the chain, they must recompute the chain up to the most recent transaction to ensure the chain is valid. The downside to this is that we will never be able to detect this change. 

Peer hashing ensures that a transaction must compute the hash of its own hash + the hash of the transaction after it (Hash(own hash + hash of next tx)). This computation is down when adding new transactions. The benefit of this is that any change at the middle of the chain must also recompute the peer hashes before and after the transaction that was changed and detection is possible when trusted party (watchers) compare the genesis pair of the chain. A genesis pair are the initial two objects/transactions added to a partition. 